### PR TITLE
Add width constraint on images in main body text

### DIFF
--- a/_sass/asylum/_layout.scss
+++ b/_sass/asylum/_layout.scss
@@ -78,6 +78,12 @@ body {
     }
 }
 
+main.text {
+    img {
+        max-width: 100%;
+    }
+}
+
 footer.footer {
     clear: both;
     margin: 0;


### PR DESCRIPTION
This forces images not to overflow the main text area (which was causing horizontal scrolling on mobile).